### PR TITLE
fixed several pytest failures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,9 @@ all:  build
 build: 
 	poetry build
 
-test:
+test: 
+	rm -rf ./Resources
+	cp -rp ./tests/Resources .
 	python3 -m pytest tests/test_sunfishcore_library.py -vvvv
 
 clean:

--- a/sunfish/lib/core.py
+++ b/sunfish/lib/core.py
@@ -6,6 +6,7 @@ import os
 import string
 import uuid
 import logging
+import pdb
 
 from sunfish.lib.exceptions import CollectionNotSupported, ResourceNotFound, AgentForwardingFailure, PropertyNotFound
 
@@ -201,16 +202,18 @@ class Core:
             raise CollectionNotSupported()
 
         payload_to_write = payload
+        #pdb.set_trace()
 
         try:
             # 1. check the path target of the operation exists
             # self.storage_backend.read(path)
+            # above done elsewhere, too soon to do here
             # 2. is needed first forward the request to the agent managing the object
             agent_response = self.objects_manager.forward_to_manager(SunfishRequestType.CREATE, path, payload=payload)
             if agent_response:
                 payload_to_write = agent_response
-            # 3. Execute any custom handler for this object type
-            self.objects_handler.dispatch(object_type, path, SunfishRequestType.CREATE, payload=payload)
+            # 3. Execute any custom handler for this object type AFTER Agent mods, if any
+            self.objects_handler.dispatch(object_type, path, SunfishRequestType.CREATE, payload=payload_to_write)
         except ResourceNotFound:
             logger.error("The collection where the resource is to be created does not exist.")
         except AgentForwardingFailure as e:

--- a/sunfish_plugins/events_handlers/redfish/redfish_event_handler.py
+++ b/sunfish_plugins/events_handlers/redfish/redfish_event_handler.py
@@ -132,7 +132,9 @@ class RedfishEventHandlersTable:
             
 
         # patch the aggregation_source object in storage with all the new resources found
-        event_handler.core.storage_backend.patch(id, aggregation_source)
+        #pdb.set_trace()
+        event_handler.core.storage_backend.patch(agg_src_path, aggregation_source)
+        logger.debug(f"\n{json.dumps(aggregation_source, indent=4)}")
         return 200
 
     @classmethod

--- a/sunfish_plugins/objects_managers/sunfish_agent/sunfish_agent_manager.py
+++ b/sunfish_plugins/objects_managers/sunfish_agent/sunfish_agent_manager.py
@@ -125,7 +125,8 @@ class SunfishAgentManager(ObjectManagerInterface):
                     data_json.close()
             else:
                 print(f"alias file {uri_alias_file} not found")
-                raise Exception
+                #no alias file, so we are done, no modifications done
+                return False
 
         except:
             raise Exception
@@ -208,7 +209,7 @@ class SunfishAgentManager(ObjectManagerInterface):
                     data_json.close()
             else:
                 print(f"alias file {uri_alias_file} not found")
-                raise Exception
+                return False
 
         except:
             raise Exception

--- a/tests/conf.json
+++ b/tests/conf.json
@@ -6,6 +6,7 @@
     },
     "backend_conf" : {
         "fs_root": "Resources",
+        "fs_private": "SunfishPrivate",
         "subscribers_root": "EventService/Subscriptions"
     },
     "events_handler": {

--- a/tests/conf_broken_module.json
+++ b/tests/conf_broken_module.json
@@ -6,6 +6,7 @@
     },
     "backend_conf" : {
         "fs_root": "Resources",
+        "fs_private": "SunfishPrivate",
         "subscribers_root": "EventService/Subscriptions"
     },
     "event_handler": {

--- a/tests/test_sunfishcore_library.py
+++ b/tests/test_sunfishcore_library.py
@@ -137,6 +137,7 @@ class TestSunfishcoreLibrary():
     @pytest.fixture(scope="session")
     def httpserver_listen_address(self):
         return ("localhost", 8080)
+        #return ("127.0.0.1", 8080)
 
     def test_event_forwarding(self, httpserver: HTTPServer):
         httpserver.expect_request("/").respond_with_data("OK")
@@ -163,12 +164,16 @@ class TestSunfishcoreLibrary():
         aggr_source_path = os.path.join(self.conf['redfish_root'], "AggregationService/AggregationSources")
         fabrics_path = os.path.join(self.conf['redfish_root'], "Fabrics")
         connection_path = os.path.join(self.conf['redfish_root'], "Fabrics/CXL/Connections")
-        httpserver.expect_request(connection_path, method="POST").respond_with_json(
+        connection_uri = os.path.join(self.conf['redfish_root'], "Fabrics/CXL/Connections/12")
+        httpserver.expect_request(connection_uri, method="POST").respond_with_json(
             tests_template.test_connection_cxl_fabric)
 
         resp = self.core.storage_backend.write(tests_template.aggregation_source)
+        print(f'resp1 = {resp}\n')
         resp = self.core.storage_backend.write(tests_template.test_fabric)
+        print(f'resp2 = {resp}\n')
         resp = self.core.create_object(connection_path, tests_template.test_connection_cxl_fabric)
+        print(f'resp3 = {resp}\n')
 
         assert resp == tests_template.test_response_connection_cxl_fabric
 


### PR DESCRIPTION
19 of the 21 tests for pytest harness are now passing.  
The test harness and test Makefile entry have been fixed to allow the 'make test' command to be executed many times in a row without manually resetting the Resource files.  Debugging is much easier now.

Most failures were in the tests/*conf config files.  Not a lot of code changes.
Still need to add many additional tests for all the new features needed when running both a sunfish server and an Agent server.